### PR TITLE
Make Process implement Executor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.dotc.nova</groupId>
 	<artifactId>nova-core</artifactId>
-	<version>1.2.3</version>
+	<version>1.3.0</version>
 
 	<dependencies>
 		<dependency>

--- a/src/main/java/com/dotc/nova/process/Process.java
+++ b/src/main/java/com/dotc/nova/process/Process.java
@@ -1,9 +1,10 @@
 package com.dotc.nova.process;
 
-import com.dotc.nova.events.EventListener;
 import com.dotc.nova.events.EventLoop;
 
-public class Process {
+import java.util.concurrent.Executor;
+
+public class Process implements Executor {
 	private final EventLoop eventLoop;
 
 	public Process(EventLoop eventLoop) {
@@ -14,11 +15,11 @@ public class Process {
 		if (callback == null) {
 			throw new IllegalArgumentException("callback must not be null");
 		}
-		eventLoop.dispatch(new EventListener() {
-			@Override
-			public void handle(Object... data) {
-				callback.run();
-			}
-		});
+		eventLoop.dispatch(data -> callback.run());
 	}
+
+    @Override
+    public void execute(Runnable command) {
+        nextTick(command);
+    }
 }


### PR DESCRIPTION
By making the ``Process`` class implement ``java.util.concurrent.Executor``, it becomes easier to integrate a Nova-based application with other Java frameworks (e.g., ``java.util.concurrent.CompletableFuture``).