### PR TITLE
respond with bad request if the handler fails

### DIFF
--- a/http/src/main/java/ch/squaredesk/nova/comm/http/RpcServer.java
+++ b/http/src/main/java/ch/squaredesk/nova/comm/http/RpcServer.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class RpcServer<InternalMessageType> extends ch.squaredesk.nova.comm.rpc.RpcServer<String, InternalMessageType, HttpSpecificInfo> {
@@ -207,7 +206,7 @@ public class RpcServer<InternalMessageType> extends ch.squaredesk.nova.comm.rpc.
                             error -> {
                                 logger.error("An error occurred trying to process HTTP request", error);
                                 try {
-                                    response.sendError(400, Optional.ofNullable(error.getMessage()).orElse("Bad request"));
+                                    response.sendError(400);
                                 } catch (Exception any) {
                                     logger.error("Failed to respond with error", any);
                                 }

--- a/http/src/main/java/ch/squaredesk/nova/comm/http/RpcServer.java
+++ b/http/src/main/java/ch/squaredesk/nova/comm/http/RpcServer.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class RpcServer<InternalMessageType> extends ch.squaredesk.nova.comm.rpc.RpcServer<String, InternalMessageType, HttpSpecificInfo> {
@@ -204,8 +205,12 @@ public class RpcServer<InternalMessageType> extends ch.squaredesk.nova.comm.rpc.
                                 }
                             },
                             error -> {
-                                // FIXME: write error or return Single.error()
                                 logger.error("An error occurred trying to process HTTP request", error);
+                                try {
+                                    response.sendError(400, Optional.ofNullable(error.getMessage()).orElse("Bad request"));
+                                } catch (Exception any) {
+                                    logger.error("Failed to respond with error", any);
+                                }
                             }
                     );
 

--- a/http/src/test/java/ch/squaredesk/nova/comm/http/RpcServerTest.java
+++ b/http/src/test/java/ch/squaredesk/nova/comm/http/RpcServerTest.java
@@ -8,6 +8,7 @@ import io.reactivex.BackpressureStrategy;
 import io.reactivex.Flowable;
 import org.glassfish.grizzly.http.server.HttpServer;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -82,6 +83,27 @@ class RpcServerTest {
 
         cdl.await(20, TimeUnit.SECONDS);
         assertThat(cdl.getCount(), is (0L));
+    }
+
+    @Test
+    void requestFailsAndErrorIsDispatched() throws Exception {
+        sut.start();
+        String path = "/fail";
+        Flowable<RpcInvocation<String, String, HttpSpecificInfo>> requests = sut.requests(path, BackpressureStrategy.BUFFER);
+        requests.subscribe(rpcInvocation -> {
+            rpcInvocation.completeExceptionally(new Exception("no content"));
+        });
+
+        String urlAsString = "http://" + rsc.interfaceName + ":" + rsc.port + path + "?p=";
+        MessageSendingInfo<URL, HttpSpecificInfo> msi = new MessageSendingInfo.Builder<URL, HttpSpecificInfo>()
+                .withDestination(new URL(urlAsString))
+                .withTransportSpecificInfo(new HttpSpecificInfo(HttpRequestMethod.POST))
+                .build();
+
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            rpcClient.sendRequest("{}", msi, 15, TimeUnit.SECONDS).blockingGet();
+        });
+        assertThat(exception.getMessage(), is("400 - no content"));
     }
 
     private void sendRestRequestInNewThread(String path, int i) {

--- a/http/src/test/java/ch/squaredesk/nova/comm/http/RpcServerTest.java
+++ b/http/src/test/java/ch/squaredesk/nova/comm/http/RpcServerTest.java
@@ -103,7 +103,7 @@ class RpcServerTest {
         RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
             rpcClient.sendRequest("{}", msi, 15, TimeUnit.SECONDS).blockingGet();
         });
-        assertThat(exception.getMessage(), is("400 - no content"));
+        assertThat(exception.getMessage(), is("400 - Bad Request"));
     }
 
     private void sendRestRequestInNewThread(String path, int i) {


### PR DESCRIPTION
Reply with BadRequest, status 400 and reason, if the RPC handler fails.