### PR TITLE
Reading file without memory leak

### DIFF
--- a/core/src/main/java/ch/squaredesk/nova/filesystem/Filesystem.java
+++ b/core/src/main/java/ch/squaredesk/nova/filesystem/Filesystem.java
@@ -15,7 +15,9 @@ import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousFileChannel;
@@ -26,9 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.HashSet;
 import java.util.Optional;
-import java.util.Scanner;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class Filesystem {
 

--- a/core/src/main/java/ch/squaredesk/nova/filesystem/Filesystem.java
+++ b/core/src/main/java/ch/squaredesk/nova/filesystem/Filesystem.java
@@ -15,10 +15,7 @@ import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.channels.AsynchronousFileChannel;
@@ -29,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.Scanner;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -58,7 +56,16 @@ public class Filesystem {
 
     public Single<String> readTextFileFully(String pathToFile) {
         String filePath = getWindowsPathUsableForNio(pathToFile);
-        return Single.fromCallable(() -> new String(Files.readAllBytes(Paths.get(filePath))));
+        return Single.fromCallable(() -> {
+            try(BufferedReader bufferedReader = Files.newBufferedReader(Paths.get(filePath))) {
+                StringBuffer buffer = new StringBuffer();
+                int c = 0;
+                while ((c = bufferedReader.read()) != -1) {
+                    buffer.append((char) c);
+                }
+                return buffer.toString();
+            }
+        });
     }
 
     public Single<String> readTextFileFullyFromClasspath(String resourcePath) {


### PR DESCRIPTION
The _AsynchronousFileChannel_ was not closed and this caused a slight memory leak.
This PR solves this and allows reading any file, as long as it fits into the memory.

Alternatively, this could work as well

`return Single.fromCallable(() -> new String(Files.readAllBytes(Paths.get(filePath))));`

while retaining the limitation of the maximum file size which can be read to be Integer.MAX_SIZE - 8 (due to the implementation of _nio.Files.readAllBytes_):

![image](https://user-images.githubusercontent.com/22636358/78596316-d8004c80-784b-11ea-8618-b599af55c45c.png)